### PR TITLE
Update Gopkg.toml and Gopkg.lock

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,29 +3,29 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:27854310d59099f8dcc61dd8af4a69f0a3597f001154b2fb4d1c41baf2e31ec1"
   name = "github.com/golang/protobuf"
   packages = [
     "proto",
     "ptypes",
     "ptypes/any",
     "ptypes/duration",
-    "ptypes/timestamp"
+    "ptypes/empty",
+    "ptypes/timestamp",
   ]
+  pruneopts = ""
   revision = "130e6b02ab059e7b717a096f397c5b60111cae74"
 
 [[projects]]
-  branch = "master"
-  name = "github.com/grpc-ecosystem/go-grpc-middleware"
-  packages = ["."]
-  revision = "6d3547c644afb325c16df96e3c7177ea6e2fdebd"
-
-[[projects]]
-  branch = "master"
+  digest = "1:8c1bb40983924efa968b5b2c1b5d2273226c7831abf740505b10fd21ab4e322a"
   name = "github.com/izumin5210/newrelic-contrib-go"
   packages = ["nrutil"]
-  revision = "eefe3d17dec6f6b7bbf4c12d8e6d243b8c86c7dd"
+  pruneopts = ""
+  revision = "c66863b8c7cce7650983f098b653baf736389bea"
+  version = "v0.1.0"
 
 [[projects]]
+  digest = "1:6921a84aa66af28f35794c0369fc5eb98081d6e23afd4c592e99ed8e7c90b11d"
   name = "github.com/newrelic/go-agent"
   packages = [
     ".",
@@ -33,13 +33,15 @@
     "internal/jsonx",
     "internal/logger",
     "internal/sysinfo",
-    "internal/utilization"
+    "internal/utilization",
   ]
+  pruneopts = ""
   revision = "29ec3cd1bb2f21d21d36da37dae52695cb2c3a17"
   version = "v1.9.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:2d5c2b468f70a1f84c0407950dc7ccbc64b1558ab2874c7fcdfa931595afe72d"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -48,12 +50,14 @@
     "idna",
     "internal/timeseries",
     "lex/httplex",
-    "trace"
+    "trace",
   ]
+  pruneopts = ""
   revision = "0a9397675ba34b2845f758fe3cd68828369c6517"
 
 [[projects]]
   branch = "master"
+  digest = "1:6ffd50f330d82d5a92f109253f3831900ccb99f973fb7d614e54ceaf6a41dcec"
   name = "golang.org/x/text"
   packages = [
     "collate",
@@ -69,17 +73,21 @@
     "unicode/bidi",
     "unicode/cldr",
     "unicode/norm",
-    "unicode/rangetable"
+    "unicode/rangetable",
   ]
+  pruneopts = ""
   revision = "1cbadb444a806fd9430d14ad08967ed91da4fa0a"
 
 [[projects]]
   branch = "master"
+  digest = "1:180913ea45cbe0072abce387a686b929908f8213106a735fe1d1273ae5239648"
   name = "google.golang.org/genproto"
   packages = ["googleapis/rpc/status"]
+  pruneopts = ""
   revision = "f676e0f3ac6395ff1a529ae59a6670878a8371a6"
 
 [[projects]]
+  digest = "1:b3c989821c14a572c49a8091fd1e832a5e53d3ae2fbf90ed3ea46cef4863aad9"
   name = "google.golang.org/grpc"
   packages = [
     ".",
@@ -96,14 +104,26 @@
     "stats",
     "status",
     "tap",
-    "transport"
+    "transport",
   ]
+  pruneopts = ""
   revision = "f92cdcd7dcdc69e81b2d7b338479a19a8723cfa3"
   version = "v1.6.0"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "0b8339ebbd6b14027b6f68364a3422d5c5e6ccfba49f9fb8abf929ae7898848a"
+  input-imports = [
+    "github.com/golang/protobuf/proto",
+    "github.com/golang/protobuf/ptypes/empty",
+    "github.com/izumin5210/newrelic-contrib-go/nrutil",
+    "github.com/newrelic/go-agent",
+    "golang.org/x/net/context",
+    "google.golang.org/grpc",
+    "google.golang.org/grpc/codes",
+    "google.golang.org/grpc/metadata",
+    "google.golang.org/grpc/stats",
+    "google.golang.org/grpc/status",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -26,9 +26,5 @@
   version = "^1.0.0"
 
 [[constraint]]
-  branch = "master"
-  name = "github.com/grpc-ecosystem/go-grpc-middleware"
-
-[[constraint]]
-  branch = "master"
   name = "github.com/izumin5210/newrelic-contrib-go"
+  version = "^0.1.0"


### PR DESCRIPTION
- Use dep 0.5.0
- Remove go-grpc-middlewares (not used)
- Re-run `dep ensure`
