### PR TITLE
Use newrelic/go-agent ^2.1

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -17,14 +17,6 @@
   revision = "130e6b02ab059e7b717a096f397c5b60111cae74"
 
 [[projects]]
-  digest = "1:b9ab1e06a2db4811ea4c9734d01856e7771a8baedea34a2bf50a4ec683b20d0d"
-  name = "github.com/izumin5210/newrelic-contrib-go"
-  packages = ["nrutil"]
-  pruneopts = ""
-  revision = "f1fce2d301bdceaf0141be8e6c369fa600253db6"
-  version = "v0.1.1"
-
-[[projects]]
   digest = "1:896fa40f307b91a53bd675225a653cde46e9183f165efd2df1b4bffe02dab40f"
   name = "github.com/newrelic/go-agent"
   packages = [
@@ -117,7 +109,6 @@
   input-imports = [
     "github.com/golang/protobuf/proto",
     "github.com/golang/protobuf/ptypes/empty",
-    "github.com/izumin5210/newrelic-contrib-go/nrutil",
     "github.com/newrelic/go-agent",
     "golang.org/x/net/context",
     "google.golang.org/grpc",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -25,19 +25,20 @@
   version = "v0.1.1"
 
 [[projects]]
-  digest = "1:6921a84aa66af28f35794c0369fc5eb98081d6e23afd4c592e99ed8e7c90b11d"
+  digest = "1:896fa40f307b91a53bd675225a653cde46e9183f165efd2df1b4bffe02dab40f"
   name = "github.com/newrelic/go-agent"
   packages = [
     ".",
     "internal",
+    "internal/cat",
     "internal/jsonx",
     "internal/logger",
     "internal/sysinfo",
     "internal/utilization",
   ]
   pruneopts = ""
-  revision = "29ec3cd1bb2f21d21d36da37dae52695cb2c3a17"
-  version = "v1.9.0"
+  revision = "46d73e6be8b4faeee70850d0df829e4fe00d6819"
+  version = "v2.1.0"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -21,10 +21,6 @@
 #  version = "2.4.0"
 
 
-[[override]]
+[[constraint]]
   name = "github.com/newrelic/go-agent"
   version = "^2.1"
-
-[[constraint]]
-  name = "github.com/izumin5210/newrelic-contrib-go"
-  version = "^0.1.1"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -21,9 +21,9 @@
 #  version = "2.4.0"
 
 
-[[constraint]]
+[[override]]
   name = "github.com/newrelic/go-agent"
-  version = "^1.0.0"
+  version = "^2.1"
 
 [[constraint]]
   name = "github.com/izumin5210/newrelic-contrib-go"

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ gRPC `stats.Handler` implementation to measure and send performances metrics to 
 
 `nrgrpc.NewServerStatsHandler` creates a [`stats.Handler`](https://godoc.org/google.golang.org/grpc/stats#Handler) instance for gRPC servers.
 When the handler is passed to a gRPC server with [`stats.StatsHandler`](https://godoc.org/google.golang.org/grpc#StatsHandler),
-it will set a [`newrelic.Transaction`](https://godoc.org/github.com/newrelic/go-agent#Transaction) into a request `context.Context` using [`nrutil.SetTransaction`](https://godoc.org/github.com/izumin5210/newrelic-contrib-go/nrutil#SetTransaction).
-So you can retrieve `newrelic.Transaction` instances with [`nrutil.Transaction`](https://godoc.org/github.com/izumin5210/newrelic-contrib-go/nrutil#Transaction).
+it will set a [`newrelic.Transaction`](https://godoc.org/github.com/newrelic/go-agent#Transaction) into a request `context.Context` using [`newrelic.NewContext`](https://godoc.org/github.com/newrelic/go-agent#NewContext).
+So you can retrieve `newrelic.Transaction` instances with [`newrelic.FromContext`](https://godoc.org/github.com/newrelic/go-agent#FromContext).
 
 ```go
 func main() {
@@ -67,7 +67,7 @@ func main() {
 	}
 
 
-	// Register http handler using `github.com/izumin5210/newrelic-contrib-go/nrhttp`.
+	// Register http handler using `https://godoc.org/github.com/newrelic/go-agent.WrapHandleFunc`.
 	// This wrapper sets `newrelic.Transaction` into the `http.Request`'s context.
 	nrhttp.WrapHandleFunc(app, "/foo", func(w http.ResponseWriter, r *http.Request) {
 		resp, err := NewFooServiceClient.BarCall(r.Context(), &BarRequest{})

--- a/client.go
+++ b/client.go
@@ -3,7 +3,6 @@ package nrgrpc
 import (
 	"context"
 
-	"github.com/izumin5210/newrelic-contrib-go/nrutil"
 	"github.com/newrelic/go-agent"
 	"google.golang.org/grpc/stats"
 )
@@ -23,7 +22,7 @@ type clientStatsHandlerImpl struct {
 }
 
 func (h *clientStatsHandlerImpl) TagRPC(ctx context.Context, info *stats.RPCTagInfo) context.Context {
-	txn := nrutil.Transaction(ctx)
+	txn := newrelic.FromContext(ctx)
 
 	if h.updateTxnName {
 		txn.SetName(info.FullMethodName)

--- a/client_test.go
+++ b/client_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/izumin5210/newrelic-contrib-go/nrutil"
 	nrgrpctesting "github.com/izumin5210/nrgrpc/testing"
+	"github.com/newrelic/go-agent"
 )
 
 func Test_Client(t *testing.T) {
@@ -16,7 +16,7 @@ func Test_Client(t *testing.T) {
 
 	txn := nrgrpctesting.NewFakeNRTxn(t, "/echo")
 
-	resp, err := ctx.Client.Echo(nrutil.SetTransaction(context.TODO(), txn), &nrgrpctesting.EchoRequest{Message: "foobar"})
+	resp, err := ctx.Client.Echo(newrelic.NewContext(context.TODO(), txn), &nrgrpctesting.EchoRequest{Message: "foobar"})
 
 	if resp == nil {
 		t.Error("The request should return a response")
@@ -39,7 +39,7 @@ func Test_Gateway(t *testing.T) {
 
 	txn := nrgrpctesting.NewFakeNRTxn(t, "/echo")
 
-	resp, err := ctx.Client.Echo(nrutil.SetTransaction(context.TODO(), txn), &nrgrpctesting.EchoRequest{Message: "foobar"})
+	resp, err := ctx.Client.Echo(newrelic.NewContext(context.TODO(), txn), &nrgrpctesting.EchoRequest{Message: "foobar"})
 
 	if resp == nil {
 		t.Error("The request should return a response")

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/izumin5210/nrgrpc
 require (
 	github.com/golang/protobuf v0.0.0-20170920220647-130e6b02ab05
 	github.com/izumin5210/newrelic-contrib-go v0.1.1
-	github.com/newrelic/go-agent v1.11.0
+	github.com/newrelic/go-agent v2.1.0+incompatible
 	golang.org/x/net v0.0.0-20170927055102-0a9397675ba3
 	golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f // indirect
 	golang.org/x/text v0.0.0-20170915090833-1cbadb444a80 // indirect

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,6 @@ module github.com/izumin5210/nrgrpc
 
 require (
 	github.com/golang/protobuf v0.0.0-20170920220647-130e6b02ab05
-	github.com/izumin5210/newrelic-contrib-go v0.1.1
 	github.com/newrelic/go-agent v2.1.0+incompatible
 	golang.org/x/net v0.0.0-20170927055102-0a9397675ba3
 	golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,5 @@
 github.com/golang/protobuf v0.0.0-20170920220647-130e6b02ab05 h1:Kesru7U6Mhpf/x7rthxAKnr586VFmoE2NdEvkOKvfjg=
 github.com/golang/protobuf v0.0.0-20170920220647-130e6b02ab05/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
-github.com/izumin5210/isql v0.0.0-20180722142634-6ef7371f8ade/go.mod h1:R6MGkhvXuHPgF408nzpimaviQmPyOzLl4GX8//IYpCc=
-github.com/izumin5210/newrelic-contrib-go v0.1.1 h1:fLpaBINRqFf0elMdxWvbpHy+TVBU9OWXZPgIUFAj2mM=
-github.com/izumin5210/newrelic-contrib-go v0.1.1/go.mod h1:aDHOTguNPm3pBbMpWmayfrFFSb4L/1oJZD4wdrXov4k=
-github.com/newrelic/go-agent v1.11.0 h1:jnd8+H6dB+93UTJHFT1wJoij5spKNN/xZ0nkw0kvt7o=
-github.com/newrelic/go-agent v1.11.0/go.mod h1:a8Fv1b/fYhFSReoTU6HDkTYIMZeSVNffmoS726Y0LzQ=
 github.com/newrelic/go-agent v2.1.0+incompatible h1:fCuxXeM4eeIKPbzffOWW6y2Dj+eYfc3yylgNZACZqkM=
 github.com/newrelic/go-agent v2.1.0+incompatible/go.mod h1:a8Fv1b/fYhFSReoTU6HDkTYIMZeSVNffmoS726Y0LzQ=
 golang.org/x/net v0.0.0-20170927055102-0a9397675ba3 h1:tTDpczhDVjW6WN3DinzKcw5juwkDTVn22I7MNlfxSXM=

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/izumin5210/newrelic-contrib-go v0.1.1 h1:fLpaBINRqFf0elMdxWvbpHy+TVBU
 github.com/izumin5210/newrelic-contrib-go v0.1.1/go.mod h1:aDHOTguNPm3pBbMpWmayfrFFSb4L/1oJZD4wdrXov4k=
 github.com/newrelic/go-agent v1.11.0 h1:jnd8+H6dB+93UTJHFT1wJoij5spKNN/xZ0nkw0kvt7o=
 github.com/newrelic/go-agent v1.11.0/go.mod h1:a8Fv1b/fYhFSReoTU6HDkTYIMZeSVNffmoS726Y0LzQ=
+github.com/newrelic/go-agent v2.1.0+incompatible h1:fCuxXeM4eeIKPbzffOWW6y2Dj+eYfc3yylgNZACZqkM=
+github.com/newrelic/go-agent v2.1.0+incompatible/go.mod h1:a8Fv1b/fYhFSReoTU6HDkTYIMZeSVNffmoS726Y0LzQ=
 golang.org/x/net v0.0.0-20170927055102-0a9397675ba3 h1:tTDpczhDVjW6WN3DinzKcw5juwkDTVn22I7MNlfxSXM=
 golang.org/x/net v0.0.0-20170927055102-0a9397675ba3/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f h1:wMNYb4v58l5UBM7MYRLPG6ZhfOqbKu7X5eyFl8ZhKvA=

--- a/server.go
+++ b/server.go
@@ -3,7 +3,6 @@ package nrgrpc
 import (
 	"context"
 
-	"github.com/izumin5210/newrelic-contrib-go/nrutil"
 	"github.com/newrelic/go-agent"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
@@ -31,7 +30,7 @@ func (h *serverStatsHandlerImpl) TagRPC(ctx context.Context, info *stats.RPCTagI
 		txn.Ignore()
 	}
 
-	ctx = nrutil.SetTransaction(ctx, txn)
+	ctx = newrelic.NewContext(ctx, txn)
 
 	return ctx
 }
@@ -39,7 +38,7 @@ func (h *serverStatsHandlerImpl) TagRPC(ctx context.Context, info *stats.RPCTagI
 func (h *serverStatsHandlerImpl) HandleRPC(ctx context.Context, s stats.RPCStats) {
 	switch s := s.(type) {
 	case *stats.End:
-		txn := nrutil.Transaction(ctx)
+		txn := newrelic.FromContext(ctx)
 		if md, ok := metadata.FromIncomingContext(ctx); ok {
 			txn.AddAttribute("metadata", md)
 		}

--- a/util.go
+++ b/util.go
@@ -8,13 +8,13 @@ import (
 
 type ctxKeyClientSegment struct{}
 
-func setSegment(ctx context.Context, seg newrelic.Segment) context.Context {
+func setSegment(ctx context.Context, seg *newrelic.Segment) context.Context {
 	return context.WithValue(ctx, ctxKeyClientSegment{}, seg)
 }
 
-func getSegment(ctx context.Context) (st newrelic.Segment, ok bool) {
+func getSegment(ctx context.Context) (st *newrelic.Segment, ok bool) {
 	if v := ctx.Value(ctxKeyClientSegment{}); v != nil {
-		st, ok = v.(newrelic.Segment)
+		st, ok = v.(*newrelic.Segment)
 	}
 	return
 }


### PR DESCRIPTION
## WHY

`newrelic/go-agent@^2.1` has support to set `newrelic.Transaction` into `context.Context` officially.
we want to follow official methods 💪 