### PR TITLE
Support for newrelic.Transaction.SetWebRequest

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -17,7 +17,8 @@
   revision = "130e6b02ab059e7b717a096f397c5b60111cae74"
 
 [[projects]]
-  digest = "1:896fa40f307b91a53bd675225a653cde46e9183f165efd2df1b4bffe02dab40f"
+  branch = "master"
+  digest = "1:dada170d17ed723bdaf2f5de3f854b983c5419df350d191911ffdd3f41348d12"
   name = "github.com/newrelic/go-agent"
   packages = [
     ".",
@@ -29,8 +30,7 @@
     "internal/utilization",
   ]
   pruneopts = ""
-  revision = "46d73e6be8b4faeee70850d0df829e4fe00d6819"
-  version = "v2.1.0"
+  revision = "36a6d903e1044f7f045c08f8bd26dd8b2ef0a986"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -50,6 +50,14 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:c2c4c39f961dde3f317a48713db65329863b61316edabf19b96784b2da8406ac"
+  name = "golang.org/x/sys"
+  packages = ["unix"]
+  pruneopts = ""
+  revision = "4d1cda033e0619309c606fc686de3adcf599539e"
+
+[[projects]]
+  branch = "master"
   digest = "1:6ffd50f330d82d5a92f109253f3831900ccb99f973fb7d614e54ceaf6a41dcec"
   name = "golang.org/x/text"
   packages = [
@@ -80,28 +88,44 @@
   revision = "f676e0f3ac6395ff1a529ae59a6670878a8371a6"
 
 [[projects]]
-  digest = "1:b3c989821c14a572c49a8091fd1e832a5e53d3ae2fbf90ed3ea46cef4863aad9"
+  digest = "1:d141efe4aaad714e3059c340901aab3147b6253e58c85dafbcca3dd8b0e88ad6"
   name = "google.golang.org/grpc"
   packages = [
     ".",
+    "balancer",
+    "balancer/base",
+    "balancer/roundrobin",
+    "binarylog/grpc_binarylog_v1",
     "codes",
     "connectivity",
     "credentials",
-    "grpclb/grpc_lb_v1/messages",
+    "credentials/internal",
+    "encoding",
+    "encoding/proto",
     "grpclog",
     "internal",
+    "internal/backoff",
+    "internal/binarylog",
+    "internal/channelz",
+    "internal/envconfig",
+    "internal/grpcrand",
+    "internal/grpcsync",
+    "internal/syscall",
+    "internal/transport",
     "keepalive",
     "metadata",
     "naming",
     "peer",
+    "resolver",
+    "resolver/dns",
+    "resolver/passthrough",
     "stats",
     "status",
     "tap",
-    "transport",
   ]
   pruneopts = ""
-  revision = "f92cdcd7dcdc69e81b2d7b338479a19a8723cfa3"
-  version = "v1.6.0"
+  revision = "df014850f6dee74ba2fc94874043a9f3f75fbfd8"
+  version = "v1.17.0"
 
 [solve-meta]
   analyzer-name = "dep"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -17,8 +17,7 @@
   revision = "130e6b02ab059e7b717a096f397c5b60111cae74"
 
 [[projects]]
-  branch = "master"
-  digest = "1:dada170d17ed723bdaf2f5de3f854b983c5419df350d191911ffdd3f41348d12"
+  digest = "1:740eceac63d29a55061c4278edfa4e713d2c13c82440d5de4d37b5fdcb540b1d"
   name = "github.com/newrelic/go-agent"
   packages = [
     ".",
@@ -30,7 +29,8 @@
     "internal/utilization",
   ]
   pruneopts = ""
-  revision = "36a6d903e1044f7f045c08f8bd26dd8b2ef0a986"
+  revision = "a138039206f5b43233e37885306a4dfbdd20e5ce"
+  version = "v2.2.0"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -22,5 +22,5 @@
 
 
 [[constraint]]
+  branch = "master"
   name = "github.com/newrelic/go-agent"
-  version = "^2.1"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -22,8 +22,8 @@
 
 
 [[constraint]]
-  branch = "master"
   name = "github.com/newrelic/go-agent"
+  version = "^2.2"
 
 [[constraint]]
   name = "google.golang.org/grpc"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -24,3 +24,7 @@
 [[constraint]]
   branch = "master"
   name = "github.com/newrelic/go-agent"
+
+[[constraint]]
+  name = "google.golang.org/grpc"
+  version = "^1.13"

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/izumin5210/nrgrpc
 
 require (
 	github.com/golang/protobuf v0.0.0-20170920220647-130e6b02ab05
-	github.com/newrelic/go-agent v2.1.0+incompatible
+	github.com/newrelic/go-agent v2.1.1-0.20181115020221-36a6d903e104+incompatible
 	golang.org/x/net v0.0.0-20170927055102-0a9397675ba3
 	golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f // indirect
 	golang.org/x/text v0.0.0-20170915090833-1cbadb444a80 // indirect

--- a/go.mod
+++ b/go.mod
@@ -7,5 +7,5 @@ require (
 	golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f // indirect
 	golang.org/x/text v0.0.0-20170915090833-1cbadb444a80 // indirect
 	google.golang.org/genproto v0.0.0-20171002232614-f676e0f3ac63 // indirect
-	google.golang.org/grpc v1.6.0
+	google.golang.org/grpc v1.13.0
 )

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/izumin5210/nrgrpc
 
 require (
 	github.com/golang/protobuf v0.0.0-20170920220647-130e6b02ab05
-	github.com/newrelic/go-agent v2.1.1-0.20181115020221-36a6d903e104+incompatible
+	github.com/newrelic/go-agent v2.2.0+incompatible
 	golang.org/x/net v0.0.0-20170927055102-0a9397675ba3
 	golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f // indirect
 	golang.org/x/text v0.0.0-20170915090833-1cbadb444a80 // indirect

--- a/go.sum
+++ b/go.sum
@@ -14,3 +14,5 @@ google.golang.org/genproto v0.0.0-20171002232614-f676e0f3ac63 h1:yNBw5bwywOTguAu
 google.golang.org/genproto v0.0.0-20171002232614-f676e0f3ac63/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/grpc v1.6.0 h1:vaySXtNtPrLJFCiET8QXtfBrqq16ynklmFGaZwLcd1M=
 google.golang.org/grpc v1.6.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
+google.golang.org/grpc v1.13.0 h1:bHIbVsCwmvbArgCJmLdgOdHFXlKqTOVjbibbS19cXHc=
+google.golang.org/grpc v1.13.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/newrelic/go-agent v2.1.0+incompatible h1:fCuxXeM4eeIKPbzffOWW6y2Dj+eY
 github.com/newrelic/go-agent v2.1.0+incompatible/go.mod h1:a8Fv1b/fYhFSReoTU6HDkTYIMZeSVNffmoS726Y0LzQ=
 github.com/newrelic/go-agent v2.1.1-0.20181115020221-36a6d903e104+incompatible h1:4Ke1f/hTLEpxrb58ttJHzjp+L/Lw4W2iE7J53o1El8o=
 github.com/newrelic/go-agent v2.1.1-0.20181115020221-36a6d903e104+incompatible/go.mod h1:a8Fv1b/fYhFSReoTU6HDkTYIMZeSVNffmoS726Y0LzQ=
+github.com/newrelic/go-agent v2.2.0+incompatible h1:h7uU1vi+U6Z8TW4az5yewM68QMScsArxezuHvDFgSvU=
+github.com/newrelic/go-agent v2.2.0+incompatible/go.mod h1:a8Fv1b/fYhFSReoTU6HDkTYIMZeSVNffmoS726Y0LzQ=
 golang.org/x/net v0.0.0-20170927055102-0a9397675ba3 h1:tTDpczhDVjW6WN3DinzKcw5juwkDTVn22I7MNlfxSXM=
 golang.org/x/net v0.0.0-20170927055102-0a9397675ba3/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f h1:wMNYb4v58l5UBM7MYRLPG6ZhfOqbKu7X5eyFl8ZhKvA=

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/golang/protobuf v0.0.0-20170920220647-130e6b02ab05 h1:Kesru7U6Mhpf/x7
 github.com/golang/protobuf v0.0.0-20170920220647-130e6b02ab05/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/newrelic/go-agent v2.1.0+incompatible h1:fCuxXeM4eeIKPbzffOWW6y2Dj+eYfc3yylgNZACZqkM=
 github.com/newrelic/go-agent v2.1.0+incompatible/go.mod h1:a8Fv1b/fYhFSReoTU6HDkTYIMZeSVNffmoS726Y0LzQ=
+github.com/newrelic/go-agent v2.1.1-0.20181115020221-36a6d903e104+incompatible h1:4Ke1f/hTLEpxrb58ttJHzjp+L/Lw4W2iE7J53o1El8o=
+github.com/newrelic/go-agent v2.1.1-0.20181115020221-36a6d903e104+incompatible/go.mod h1:a8Fv1b/fYhFSReoTU6HDkTYIMZeSVNffmoS726Y0LzQ=
 golang.org/x/net v0.0.0-20170927055102-0a9397675ba3 h1:tTDpczhDVjW6WN3DinzKcw5juwkDTVn22I7MNlfxSXM=
 golang.org/x/net v0.0.0-20170927055102-0a9397675ba3/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f h1:wMNYb4v58l5UBM7MYRLPG6ZhfOqbKu7X5eyFl8ZhKvA=

--- a/request.go
+++ b/request.go
@@ -61,5 +61,5 @@ func (r *request) Method() string {
 
 func (r *request) Transport() newrelic.TransportType {
 	// TODO: should define `TransportGRPC"
-	return newrelic.TransportUnknown
+	return newrelic.TransportOther
 }

--- a/request.go
+++ b/request.go
@@ -14,7 +14,7 @@ type request struct {
 	header http.Header
 }
 
-func newRequest(ctx context.Context, fullMethodName string) newrelic.Request {
+func newRequest(ctx context.Context, fullMethodName string) newrelic.WebRequest {
 	h := http.Header{}
 	h.Add("content-type", "application/grpc")
 	md, ok := metadata.FromIncomingContext(ctx)

--- a/request.go
+++ b/request.go
@@ -1,0 +1,51 @@
+package nrgrpc
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+
+	newrelic "github.com/newrelic/go-agent"
+	"google.golang.org/grpc/metadata"
+)
+
+type request struct {
+	url    *url.URL
+	header http.Header
+}
+
+func newRequest(ctx context.Context, fullMethodName string) newrelic.Request {
+	h := http.Header{}
+	h.Add("content-type", "application/grpc")
+	md, ok := metadata.FromIncomingContext(ctx)
+	if ok {
+		if v := md.Get(newrelic.DistributedTracePayloadHeader); len(v) > 0 {
+			h.Add(newrelic.DistributedTracePayloadHeader, v[0])
+		}
+		if v := md.Get("user-agent"); len(v) > 0 {
+			h.Add("user-agent", v[0])
+		}
+	}
+
+	return &request{
+		url:    &url.URL{Path: fullMethodName},
+		header: h,
+	}
+}
+
+func (r *request) Header() http.Header {
+	return r.header
+}
+
+func (r *request) URL() *url.URL {
+	return r.url
+}
+
+func (r *request) Method() string {
+	return ""
+}
+
+func (r *request) Transport() newrelic.TransportType {
+	// TODO: should define `TransportGRPC"
+	return newrelic.TransportUnknown
+}

--- a/server.go
+++ b/server.go
@@ -30,6 +30,7 @@ func (h *serverStatsHandlerImpl) TagRPC(ctx context.Context, info *stats.RPCTagI
 		txn.Ignore()
 	}
 
+	txn.SetWebRequest(newRequest(ctx, info.FullMethodName))
 	ctx = newrelic.NewContext(ctx, txn)
 
 	return ctx

--- a/testing/newrelic.go
+++ b/testing/newrelic.go
@@ -90,6 +90,11 @@ func (t *FakeNRTxn) StartSegmentNow() newrelic.SegmentStartTime {
 	return newrelic.SegmentStartTime{}
 }
 
+// SetWebRequest implements the newrelic.Transaction interface.
+func (t *FakeNRTxn) SetWebRequest(req interface{}) error {
+	return nil
+}
+
 // CheckEnded fails the test if the transaction has been ended.
 func (t *FakeNRTxn) CheckEnded() {
 	t.t.Helper()

--- a/testing/newrelic.go
+++ b/testing/newrelic.go
@@ -91,7 +91,7 @@ func (t *FakeNRTxn) StartSegmentNow() newrelic.SegmentStartTime {
 }
 
 // SetWebRequest implements the newrelic.Transaction interface.
-func (t *FakeNRTxn) SetWebRequest(req interface{}) error {
+func (t *FakeNRTxn) SetWebRequest(req newrelic.WebRequest) error {
 	return nil
 }
 


### PR DESCRIPTION
## WHY
related: https://github.com/newrelic/go-agent/issues/78 https://github.com/newrelic/go-agent/pull/70

`newrelic/go-agent@^v2.2` supports `Transaction.SetWebRequest`.

