### PR TITLE
fix: README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,8 @@ func main() {
 	}
 
 	// Initiailze a `newrelic.Appliation`
-	nrapp, err := newrelic.NewApplication(newrelic.Config{
-		AppName: "your_app",
-		License: "your_license_key",
-	})
+	cfg := newrelic.NewConfig("your_app","your_license_key")
+	nrapp, err := newrelic.NewApplication(cfg)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
newrelic.Config struct has an `enable` field, with using
newrelic.Config{} to make conifg, its default value is false.